### PR TITLE
Add docker stats collector and test

### DIFF
--- a/src/collectors/docker_stats/docker_stats.py
+++ b/src/collectors/docker_stats/docker_stats.py
@@ -1,0 +1,88 @@
+"""
+The DockerStatsCollector collects stats from the docker daemon about currently running
+containers.
+"""
+
+import diamond.collector
+
+try:
+  import docker
+except ImportError:
+  docker = None
+
+def env_list_to_dict(env_list):
+  env_dict = {}
+  for pair in env_list:
+    tokens = pair.split("=",1)
+    env_dict[tokens[0]] = tokens[1]
+  return env_dict
+
+class DockerStatsCollector(diamond.collector.Collector):
+
+  def get_default_config_help(self):
+    config_help = super(DockerStatsCollector, self).get_default_config_help()
+    config_help.update({
+      'client_url': 'The url to connect to the docker daemon',
+      'name_from_env': 'If specified, use the named environment variable to populate container name',
+    })
+    return config_help
+
+  def get_default_config(self):
+    """
+    Returns the default collector settings
+    """
+    config = super(DockerStatsCollector, self).get_default_config()
+    config.update({
+      'client_url': 'unix://var/run/docker.sock',
+      'name_from_env': None,
+      'path': 'docker',
+    })
+    return config
+
+  def collect(self):
+    """
+    Collect docker stats
+    """
+
+    # Require docker client lib to get stats
+    if docker is None:
+      self.log.error('Unable to import docker')
+      return None
+
+    try:
+      client = docker.Client(base_url=self.config['client_url'])
+      container_ids = [container['Id'] for container in client.containers()]
+
+      for container_id in container_ids:
+        container = client.inspect_container(container_id)
+        name = container['Name']
+        if self.config['name_from_env']:
+          # Grab name from environment variable if configured
+          env_dict = env_list_to_dict(container['Config']['Env'])
+          name = env_dict.get(self.config['name_from_env'], name)
+
+        metrics_prefix = '.'.join([name, container_id])
+        stats = client.stats(container_id, True).next()
+
+        # CPU Stats
+        for ix, cpu_time in enumerate(stats['cpu_stats']['cpu_usage']['percpu_usage']):
+          metric_name = '.'.join([metrics_prefix, 'cpu' + str(ix), 'user'])
+          self.publish(metric_name,
+                       int(self.derivative(metric_name,
+                                           cpu_time / 10000000.0,
+                                           diamond.collector.MAX_COUNTER)))
+
+        # Memory Stats
+        metric_name = '.'.join([metrics_prefix, 'mem', 'rss'])
+        self.publish(metric_name,
+                     stats['memory_stats']['stats']['total_rss'])
+
+        # Network Stats
+        for stat in [u'rx_bytes', u'tx_bytes']:
+          self.publish('.'.join([metrics_prefix, 'net', stat]),
+                       stats['network'][stat])
+      return True
+
+    except Exception as e:
+      self.log.error("Couldn't collect from docker: %s", e)
+      return None

--- a/src/collectors/docker_stats/test/testdockerstats.py
+++ b/src/collectors/docker_stats/test/testdockerstats.py
@@ -1,0 +1,152 @@
+from test import CollectorTestCase
+from test import run_only
+from test import get_collector_config
+from mock import Mock
+from mock import MagicMock
+from mock import patch
+
+from diamond.collector import Collector
+from docker_stats import DockerStatsCollector
+
+def run_only_if_docker_is_available(func):
+  try:
+    import docker
+  except ImportError:
+    docker = None
+    pred = lambda: docker is not None
+    return run_only(func, pred)
+
+
+def get_client_mock():
+  client_mock = Mock()
+  client_mock.containers.return_value = [
+    {
+      u'Id': u'146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec'
+    }]
+  stats_mock = MagicMock()
+  client_mock.stats.return_value = stats_mock
+  stats_mock.next.side_effect = [
+    {
+      u'cpu_stats': {
+        u'cpu_usage': {
+          u'percpu_usage': [0,
+                            0,
+                            0,
+                            0],
+        }
+      },
+      u'memory_stats': {
+        u'stats': {
+          u'total_rss': 100,
+        }
+      },
+      u'network': {
+        u'rx_bytes': 100,
+        u'tx_bytes': 100,
+      }
+    },
+    {
+      u'cpu_stats': {
+        u'cpu_usage': {
+          u'percpu_usage': [10000000,
+                            20000000,
+                            30000000,
+                            40000000],
+        }
+      },
+      u'memory_stats': {
+        u'stats': {
+          u'total_rss': 200,
+        }
+      },
+      u'network': {
+        u'rx_bytes': 200,
+        u'tx_bytes': 200,
+      }
+    }
+  ]
+
+  client_mock.inspect_container.return_value = {
+    u'Id': u'146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec',
+    u'Name': u'test',
+    u'Config': {
+      u'Env': ["TEST=newname"]
+    }
+  }
+  return client_mock
+
+
+class TestDockerStatsCollector(CollectorTestCase):
+  def setUp(self):
+    config = get_collector_config('DockerStatsCollector', {
+      'client_url': 'localhost:4243',
+      'name_from_env': None,
+      'interval': 1,
+    })
+    self.collector = DockerStatsCollector(config, None)
+
+  def test_import(self):
+    self.assertTrue(DockerStatsCollector)
+
+  @patch.object(Collector, 'publish')
+  @patch('docker.Client')
+  def test_should_publish_values_correctly(self, docker_client_mock, publish_mock):
+    client_mock = get_client_mock()
+    docker_client_mock.return_value = client_mock
+    self.collector.collect()
+    metrics = {
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 100,
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 100,
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 100,
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+    self.collector.collect()
+    metrics = {
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 200,
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 200,
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 200,
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu0.user': 1,
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu1.user': 2,
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu2.user': 3,
+      'test.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu3.user': 4,
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+
+class TestDockerStatsCollectorWithEnv(CollectorTestCase):
+  def setUp(self):
+    config = get_collector_config('DockerStatsCollector', {
+      'client_url': 'localhost:4243',
+      'name_from_env': 'TEST',
+      'interval': 1,
+    })
+    self.collector = DockerStatsCollector(config, None)
+
+  def test_import(self):
+    self.assertTrue(DockerStatsCollector)
+
+  @patch.object(Collector, 'publish')
+  @patch('docker.Client')
+  def test_should_publish_values_correctly(self, docker_client_mock, publish_mock):
+    client_mock = get_client_mock()
+    docker_client_mock.return_value = client_mock
+    self.collector.collect()
+    metrics = {
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 100,
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 100,
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 100,
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+    self.collector.collect()
+    metrics = {
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 200,
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 200,
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 200,
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu0.user': 1,
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu1.user': 2,
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu2.user': 3,
+      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu3.user': 4,
+    }
+    self.assertPublishedMany(publish_mock, metrics)


### PR DESCRIPTION
This PR implements a docker stats collector for diamond.  The idea is to use this collector on our mesos machines in order to collect per-container metrics (cpu/mem/network) similar to the instance metrics we collect for machines today

JIRA task: https://clever.atlassian.net/browse/INFRA-1037
