### PR TITLE
Set up drone testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,15 @@
+image: python2.7
+notify:
+  email:
+    recipients:
+    - drone@clever.com
+  slack:
+    on_failure: true
+    on_started: false
+    on_success: false
+    webhook_url: $$slack_webhook
+script:
+- sudo apt-get -yq update
+- sudo apt-get install libpq-dev lm-sensors libsensors4
+- pip install -q --upgrade setuptools && pip install -q -r requirements.txt
+- python test.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+MySQL-python
+PyYAML
+beanstalkc
+bernhard
+boto
+configobj
+docker-py
+kitchen
+mock==1.0.1
+psutil
+pymongo<3.0
+# Disable due to bad test cases
+# https://github.com/BrightcoveOS/Diamond/issues/650
+#pyrabbit
+python-statsd
+pyutmp
+redis
+simplejson
+setproctitle
+psycopg2
+PySensors


### PR DESCRIPTION
The upstream project https://github.com/python-diamond/diamond uses Travis CI, so this is mostly just a port of `.travis.yml` to `.drone.yml`.

A couple of notes:
- `requirements.txt` is a copy of `.travis.requirements.txt` since that name is more general-purpose. I can also just make this a symlink or rm the travis file.
- We need to pin `mock==1.0.1` because `mock 1.1.1` on python 2.7.\* requires `setuptools>=17.1` in order to be installed, or will fail on missing the funcsigs module. See https://github.com/testing-cabal/mock/issues/261 for more context. Upstream tests against python 2.6, but we should continue to use 2.7 since that is the version used in development/staging and production.
