### PR TITLE
sanitize docker names for better influx templating

### DIFF
--- a/src/collectors/docker_stats/docker_stats.py
+++ b/src/collectors/docker_stats/docker_stats.py
@@ -17,6 +17,8 @@ def env_list_to_dict(env_list):
     env_dict[tokens[0]] = tokens[1]
   return env_dict
 
+def sanitize_slashes(name):
+  return ".".join(name.strip("/").split("/"))
 class DockerStatsCollector(diamond.collector.Collector):
 
   def get_default_config_help(self):
@@ -24,6 +26,7 @@ class DockerStatsCollector(diamond.collector.Collector):
     config_help.update({
       'client_url': 'The url to connect to the docker daemon',
       'name_from_env': 'If specified, use the named environment variable to populate container name',
+      'sanitize_slashes': 'Replace slashes in container name with \".\"\'s, defaults to True'
     })
     return config_help
 
@@ -36,6 +39,7 @@ class DockerStatsCollector(diamond.collector.Collector):
       'client_url': 'unix://var/run/docker.sock',
       'name_from_env': None,
       'path': 'docker',
+      'sanitize_slashes': True,
     })
     return config
 
@@ -60,6 +64,8 @@ class DockerStatsCollector(diamond.collector.Collector):
           # Grab name from environment variable if configured
           env_dict = env_list_to_dict(container['Config']['Env'])
           name = env_dict.get(self.config['name_from_env'], name)
+        if self.config['sanitize_slashes']:
+          name = sanitize_slashes(name)
 
         metrics_prefix = '.'.join([name, container_id])
         stats = client.stats(container_id, True).next()

--- a/src/collectors/docker_stats/test/testdockerstats.py
+++ b/src/collectors/docker_stats/test/testdockerstats.py
@@ -70,7 +70,7 @@ def get_client_mock():
     u'Id': u'146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec',
     u'Name': u'test',
     u'Config': {
-      u'Env': ["TEST=newname"]
+      u'Env': ["TEST=/new/name/"]
     }
   }
   return client_mock
@@ -133,20 +133,58 @@ class TestDockerStatsCollectorWithEnv(CollectorTestCase):
     docker_client_mock.return_value = client_mock
     self.collector.collect()
     metrics = {
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 100,
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 100,
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 100,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 100,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 100,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 100,
     }
     self.assertPublishedMany(publish_mock, metrics)
 
     self.collector.collect()
     metrics = {
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 200,
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 200,
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 200,
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu0.user': 1,
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu1.user': 2,
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu2.user': 3,
-      'newname.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu3.user': 4,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 200,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 200,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 200,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu0.user': 1,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu1.user': 2,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu2.user': 3,
+      'new.name.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu3.user': 4,
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+class TestDockerStatsCollectorWithoutReplaceSlashes(CollectorTestCase):
+  def setUp(self):
+    config = get_collector_config('DockerStatsCollector', {
+      'client_url': 'localhost:4243',
+      'name_from_env': 'TEST',
+      'interval': 1,
+      'sanitize_slashes': False,
+    })
+    self.collector = DockerStatsCollector(config, None)
+
+  def test_import(self):
+    self.assertTrue(DockerStatsCollector)
+
+  @patch.object(Collector, 'publish')
+  @patch('docker.Client')
+  def test_should_publish_values_correctly(self, docker_client_mock, publish_mock):
+    client_mock = get_client_mock()
+    docker_client_mock.return_value = client_mock
+    self.collector.collect()
+    metrics = {
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 100,
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 100,
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 100,
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+    self.collector.collect()
+    metrics = {
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.mem.rss': 200,
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.tx_bytes': 200,
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.net.rx_bytes': 200,
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu0.user': 1,
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu1.user': 2,
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu2.user': 3,
+      '/new/name/.146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec.cpu3.user': 4,
     }
     self.assertPublishedMany(publish_mock, metrics)


### PR DESCRIPTION
Before metrics would contain names like "/env/service", but this makes templating difficultin grafana because we would need to escape the slashes.  This adds an option (on by default) to convert those names to "env.service".
