### PR TITLE
don't stream docker stats

### DIFF
--- a/src/collectors/docker_stats/docker_stats.py
+++ b/src/collectors/docker_stats/docker_stats.py
@@ -68,7 +68,7 @@ class DockerStatsCollector(diamond.collector.Collector):
           name = sanitize_slashes(name)
 
         metrics_prefix = '.'.join([name, container_id])
-        stats = client.stats(container_id, True).next()
+        stats = client.stats(container_id, True, stream=False)
 
         # CPU Stats
         for ix, cpu_time in enumerate(stats['cpu_stats']['cpu_usage']['percpu_usage']):

--- a/src/collectors/docker_stats/test/testdockerstats.py
+++ b/src/collectors/docker_stats/test/testdockerstats.py
@@ -23,9 +23,7 @@ def get_client_mock():
     {
       u'Id': u'146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec'
     }]
-  stats_mock = MagicMock()
-  client_mock.stats.return_value = stats_mock
-  stats_mock.next.side_effect = [
+  client_mock.stats.side_effect = [
     {
       u'cpu_stats': {
         u'cpu_usage': {


### PR DESCRIPTION
- streaming stats leaves open connections that cause errors when those
  containers are destroyed (also are persistant and not useful).
- This change requires docker-py 1.6+
