### PR TITLE
Update docker stats collector for ecs

### DIFF
--- a/src/collectors/docker_stats/docker_stats.py
+++ b/src/collectors/docker_stats/docker_stats.py
@@ -110,9 +110,14 @@ class DockerStatsCollector(diamond.collector.Collector):
 
 
         # Network Stats
-        for stat in [u'rx_bytes', u'tx_bytes']:
-          self.publish('.'.join([metrics_prefix, 'net', stat]),
-                       stats['network'][stat])
+        networks = stats.get('networks', [])
+        if not networks:
+          networks = {'eth0': stats['network']}
+
+        for network_name, network in networks.iteritems():
+          for stat in [u'rx_bytes', u'tx_bytes']:
+            self.publish('.'.join([metrics_prefix, 'net', network_name, stat]),
+                         network[stat])
       return True
 
     except SIGALRMException as e:

--- a/src/collectors/docker_stats/docker_stats.py
+++ b/src/collectors/docker_stats/docker_stats.py
@@ -112,7 +112,9 @@ class DockerStatsCollector(diamond.collector.Collector):
         # Network Stats
         networks = stats.get('networks', {})
         if not networks:
-          networks = {'eth0': stats['network']}
+          single_network = stats.get('network', {})
+          if single_network:
+            networks = {'eth0': stats['network']}
 
         for network_name, network in networks.iteritems():
           for stat in [u'rx_bytes', u'tx_bytes']:

--- a/src/collectors/docker_stats/docker_stats.py
+++ b/src/collectors/docker_stats/docker_stats.py
@@ -110,7 +110,7 @@ class DockerStatsCollector(diamond.collector.Collector):
 
 
         # Network Stats
-        networks = stats.get('networks', [])
+        networks = stats.get('networks', {})
         if not networks:
           networks = {'eth0': stats['network']}
 

--- a/src/collectors/docker_stats/docker_stats.py
+++ b/src/collectors/docker_stats/docker_stats.py
@@ -18,8 +18,9 @@ def env_list_to_dict(env_list):
     env_dict[tokens[0]] = tokens[1]
   return env_dict
 
-def sanitize_slashes(name):
-  return ".".join(name.strip("/").split("/"))
+def sanitize_delim(name, delim):
+  return ".".join(name.strip(delim).split(delim))
+
 class DockerStatsCollector(diamond.collector.Collector):
 
   def get_default_config_help(self):
@@ -27,7 +28,8 @@ class DockerStatsCollector(diamond.collector.Collector):
     config_help.update({
       'client_url': 'The url to connect to the docker daemon',
       'name_from_env': 'If specified, use the named environment variable to populate container name',
-      'sanitize_slashes': 'Replace slashes in container name with \".\"\'s, defaults to True'
+      'sanitize_slashes': 'Replace slashes in container name with \".\"\'s, defaults to True',
+      'ecs_mode': 'Enables pulling container name and env from \'tag\' docker label, and using task ARN instead of container id, defaults to False',
     })
     return config_help
 
@@ -41,6 +43,7 @@ class DockerStatsCollector(diamond.collector.Collector):
       'name_from_env': None,
       'path': 'docker',
       'sanitize_slashes': True,
+      'ecs_mode': False,
     })
     return config
 
@@ -61,14 +64,25 @@ class DockerStatsCollector(diamond.collector.Collector):
       for container_id in container_ids:
         container = client.inspect_container(container_id)
         name = container['Name']
+        idlabel = container_id[:12]
         if self.config['name_from_env']:
           # Grab name from environment variable if configured
           env_dict = env_list_to_dict(container['Config']['Env'])
           name = env_dict.get(self.config['name_from_env'], name)
         if self.config['sanitize_slashes']:
-          name = sanitize_slashes(name)
+          name = sanitize_delim(name, "/")
+        if self.config['ecs_mode']:
+          labels = container['Config']['Labels']
+          tag = labels.get('tag', '')
+          arn = labels.get('com.amazonaws.ecs.task-arn', '')
+          if arn and tag:
+            # only grab the first part of the task UUID
+            parts = arn.split("/")
+            idlabel = parts[1][:8]
+            name = sanitize_delim(tag, "--")
 
-        metrics_prefix = '.'.join([name, container_id[:12]])
+
+        metrics_prefix = '.'.join([name, idlabel, "docker"])
         stats = client.stats(container_id, True, stream=False)
 
         # CPU Stats

--- a/src/collectors/docker_stats/docker_stats.py
+++ b/src/collectors/docker_stats/docker_stats.py
@@ -81,7 +81,6 @@ class DockerStatsCollector(diamond.collector.Collector):
             idlabel = parts[1][:8]
             name = sanitize_delim(tag, "--")
 
-
         metrics_prefix = '.'.join([name, idlabel, "docker"])
         stats = client.stats(container_id, True, stream=False)
 

--- a/src/collectors/docker_stats/test/testdockerstats.py
+++ b/src/collectors/docker_stats/test/testdockerstats.py
@@ -72,7 +72,11 @@ def get_client_mock():
     u'Id': u'146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec',
     u'Name': u'test',
     u'Config': {
-      u'Env': ["TEST=/new/name/"]
+      u'Env': ["TEST=/new/name/"],
+      u'Labels': {
+        u'tag': u'ecs--name',
+        u'com.amazonaws.ecs.task-arn': u'arn:aws:ecs:us-west-1:000000000000:task/abcdef12-3456-789a-bcde-f123456789ab',
+      }
     }
   }
   return client_mock
@@ -97,24 +101,24 @@ class TestDockerStatsCollector(CollectorTestCase):
     docker_client_mock.return_value = client_mock
     self.collector.collect()
     metrics = {
-      'test.146979a53289.mem.rss': 100,
-      'test.146979a53289.mem.limit': 500,
-      'test.146979a53289.net.tx_bytes': 100,
-      'test.146979a53289.net.rx_bytes': 100,
+      'test.146979a53289.docker.mem.rss': 100,
+      'test.146979a53289.docker.mem.limit': 500,
+      'test.146979a53289.docker.net.tx_bytes': 100,
+      'test.146979a53289.docker.net.rx_bytes': 100,
     }
     self.assertPublishedMany(publish_mock, metrics)
 
     self.collector.collect()
     metrics = {
-      'test.146979a53289.mem.rss': 200,
-      'test.146979a53289.mem.limit': 500,
-      'test.146979a53289.net.tx_bytes': 200,
-      'test.146979a53289.net.rx_bytes': 200,
-      'test.146979a53289.cpu0.user': 1,
-      'test.146979a53289.cpu1.user': 2,
-      'test.146979a53289.cpu2.user': 3,
-      'test.146979a53289.cpu3.user': 4,
-      'test.146979a53289.cpu_total.user': 10
+      'test.146979a53289.docker.mem.rss': 200,
+      'test.146979a53289.docker.mem.limit': 500,
+      'test.146979a53289.docker.net.tx_bytes': 200,
+      'test.146979a53289.docker.net.rx_bytes': 200,
+      'test.146979a53289.docker.cpu0.user': 1,
+      'test.146979a53289.docker.cpu1.user': 2,
+      'test.146979a53289.docker.cpu2.user': 3,
+      'test.146979a53289.docker.cpu3.user': 4,
+      'test.146979a53289.docker.cpu_total.user': 10
     }
     self.assertPublishedMany(publish_mock, metrics)
 
@@ -138,24 +142,24 @@ class TestDockerStatsCollectorWithEnv(CollectorTestCase):
     docker_client_mock.return_value = client_mock
     self.collector.collect()
     metrics = {
-      'new.name.146979a53289.mem.rss': 100,
-      'new.name.146979a53289.mem.limit': 500,
-      'new.name.146979a53289.net.tx_bytes': 100,
-      'new.name.146979a53289.net.rx_bytes': 100,
+      'new.name.146979a53289.docker.mem.rss': 100,
+      'new.name.146979a53289.docker.mem.limit': 500,
+      'new.name.146979a53289.docker.net.tx_bytes': 100,
+      'new.name.146979a53289.docker.net.rx_bytes': 100,
     }
     self.assertPublishedMany(publish_mock, metrics)
 
     self.collector.collect()
     metrics = {
-      'new.name.146979a53289.mem.rss': 200,
-      'new.name.146979a53289.mem.limit': 500,
-      'new.name.146979a53289.net.tx_bytes': 200,
-      'new.name.146979a53289.net.rx_bytes': 200,
-      'new.name.146979a53289.cpu0.user': 1,
-      'new.name.146979a53289.cpu1.user': 2,
-      'new.name.146979a53289.cpu2.user': 3,
-      'new.name.146979a53289.cpu3.user': 4,
-      'new.name.146979a53289.cpu_total.user': 10
+      'new.name.146979a53289.docker.mem.rss': 200,
+      'new.name.146979a53289.docker.mem.limit': 500,
+      'new.name.146979a53289.docker.net.tx_bytes': 200,
+      'new.name.146979a53289.docker.net.rx_bytes': 200,
+      'new.name.146979a53289.docker.cpu0.user': 1,
+      'new.name.146979a53289.docker.cpu1.user': 2,
+      'new.name.146979a53289.docker.cpu2.user': 3,
+      'new.name.146979a53289.docker.cpu3.user': 4,
+      'new.name.146979a53289.docker.cpu_total.user': 10
     }
     self.assertPublishedMany(publish_mock, metrics)
 
@@ -179,23 +183,63 @@ class TestDockerStatsCollectorWithoutReplaceSlashes(CollectorTestCase):
     docker_client_mock.return_value = client_mock
     self.collector.collect()
     metrics = {
-      '/new/name/.146979a53289.mem.rss': 100,
-      '/new/name/.146979a53289.mem.limit': 500,
-      '/new/name/.146979a53289.net.tx_bytes': 100,
-      '/new/name/.146979a53289.net.rx_bytes': 100,
+      '/new/name/.146979a53289.docker.mem.rss': 100,
+      '/new/name/.146979a53289.docker.mem.limit': 500,
+      '/new/name/.146979a53289.docker.net.tx_bytes': 100,
+      '/new/name/.146979a53289.docker.net.rx_bytes': 100,
     }
     self.assertPublishedMany(publish_mock, metrics)
 
     self.collector.collect()
     metrics = {
-      '/new/name/.146979a53289.mem.rss': 200,
-      '/new/name/.146979a53289.mem.limit': 500,
-      '/new/name/.146979a53289.net.tx_bytes': 200,
-      '/new/name/.146979a53289.net.rx_bytes': 200,
-      '/new/name/.146979a53289.cpu0.user': 1,
-      '/new/name/.146979a53289.cpu1.user': 2,
-      '/new/name/.146979a53289.cpu2.user': 3,
-      '/new/name/.146979a53289.cpu3.user': 4,
-      '/new/name/.146979a53289.cpu_total.user': 10
+      '/new/name/.146979a53289.docker.mem.rss': 200,
+      '/new/name/.146979a53289.docker.mem.limit': 500,
+      '/new/name/.146979a53289.docker.net.tx_bytes': 200,
+      '/new/name/.146979a53289.docker.net.rx_bytes': 200,
+      '/new/name/.146979a53289.docker.cpu0.user': 1,
+      '/new/name/.146979a53289.docker.cpu1.user': 2,
+      '/new/name/.146979a53289.docker.cpu2.user': 3,
+      '/new/name/.146979a53289.docker.cpu3.user': 4,
+      '/new/name/.146979a53289.docker.cpu_total.user': 10
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+class TestDockerStatsCollectorWithECSMode(CollectorTestCase):
+  def setUp(self):
+    config = get_collector_config('DockerStatsCollector', {
+      'client_url': 'localhost:4243',
+      'interval': 1,
+      'ecs_mode': True,
+    })
+    self.collector = DockerStatsCollector(config, None)
+
+  def test_import(self):
+    self.assertTrue(DockerStatsCollector)
+
+  @patch.object(Collector, 'publish')
+  @patch('docker.Client')
+  def test_should_publish_values_correctly(self, docker_client_mock, publish_mock):
+    client_mock = get_client_mock()
+    docker_client_mock.return_value = client_mock
+    self.collector.collect()
+    metrics = {
+      'ecs.name.abcdef12.docker.mem.rss': 100,
+      'ecs.name.abcdef12.docker.mem.limit': 500,
+      'ecs.name.abcdef12.docker.net.tx_bytes': 100,
+      'ecs.name.abcdef12.docker.net.rx_bytes': 100,
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+    self.collector.collect()
+    metrics = {
+      'ecs.name.abcdef12.docker.mem.rss': 200,
+      'ecs.name.abcdef12.docker.mem.limit': 500,
+      'ecs.name.abcdef12.docker.net.tx_bytes': 200,
+      'ecs.name.abcdef12.docker.net.rx_bytes': 200,
+      'ecs.name.abcdef12.docker.cpu0.user': 1,
+      'ecs.name.abcdef12.docker.cpu1.user': 2,
+      'ecs.name.abcdef12.docker.cpu2.user': 3,
+      'ecs.name.abcdef12.docker.cpu3.user': 4,
+      'ecs.name.abcdef12.docker.cpu_total.user': 10
     }
     self.assertPublishedMany(publish_mock, metrics)

--- a/src/collectors/docker_stats/test/testdockerstats.py
+++ b/src/collectors/docker_stats/test/testdockerstats.py
@@ -81,6 +81,72 @@ def get_client_mock():
   }
   return client_mock
 
+def get_client_multi_network_mock():
+  client_mock = Mock()
+  client_mock.containers.return_value = [
+    {
+      u'Id': u'146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec'
+    }]
+  client_mock.stats.side_effect = [
+    {
+      u'cpu_stats': {
+        u'cpu_usage': {
+          u'total_usage': 0,
+          u'percpu_usage': [0,
+                            0,
+                            0,
+                            0],
+        }
+      },
+      u'memory_stats': {
+        u'stats': {
+          u'total_rss': 100,
+        },
+        u'limit': 500
+      },
+      u'network': {
+        u'rx_bytes': 100,
+        u'tx_bytes': 100,
+      }
+    },
+    {
+      u'cpu_stats': {
+        u'cpu_usage': {
+          u'total_usage': 100000000,
+          u'percpu_usage': [10000000,
+                            20000000,
+                            30000000,
+                            40000000],
+        }
+      },
+      u'memory_stats': {
+        u'stats': {
+          u'total_rss': 200,
+        },
+        u'limit': 500
+      },
+      u'networks': {
+        'eth0': {
+          u'rx_bytes': 200,
+          u'tx_bytes': 200,
+        }
+      }
+    }
+  ]
+
+  client_mock.inspect_container.return_value = {
+    u'Id': u'146979a5328952af505cd43123b45b06c38db8679aaadb2a4c18ad699a5cbeec',
+    u'Name': u'test',
+    u'Config': {
+      u'Env': ["TEST=/new/name/"],
+      u'Labels': {
+        u'tag': u'ecs--name',
+        u'com.amazonaws.ecs.task-arn': u'arn:aws:ecs:us-west-1:000000000000:task/abcdef12-3456-789a-bcde-f123456789ab',
+      }
+    }
+  }
+  return client_mock
+
 
 class TestDockerStatsCollector(CollectorTestCase):
   def setUp(self):
@@ -103,8 +169,8 @@ class TestDockerStatsCollector(CollectorTestCase):
     metrics = {
       'test.146979a53289.docker.mem.rss': 100,
       'test.146979a53289.docker.mem.limit': 500,
-      'test.146979a53289.docker.net.tx_bytes': 100,
-      'test.146979a53289.docker.net.rx_bytes': 100,
+      'test.146979a53289.docker.net.eth0.tx_bytes': 100,
+      'test.146979a53289.docker.net.eth0.rx_bytes': 100,
     }
     self.assertPublishedMany(publish_mock, metrics)
 
@@ -112,8 +178,48 @@ class TestDockerStatsCollector(CollectorTestCase):
     metrics = {
       'test.146979a53289.docker.mem.rss': 200,
       'test.146979a53289.docker.mem.limit': 500,
-      'test.146979a53289.docker.net.tx_bytes': 200,
-      'test.146979a53289.docker.net.rx_bytes': 200,
+      'test.146979a53289.docker.net.eth0.tx_bytes': 200,
+      'test.146979a53289.docker.net.eth0.rx_bytes': 200,
+      'test.146979a53289.docker.cpu0.user': 1,
+      'test.146979a53289.docker.cpu1.user': 2,
+      'test.146979a53289.docker.cpu2.user': 3,
+      'test.146979a53289.docker.cpu3.user': 4,
+      'test.146979a53289.docker.cpu_total.user': 10
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+class TestDockerStatsCollectorMultiNetwork(CollectorTestCase):
+  def setUp(self):
+    config = get_collector_config('DockerStatsCollector', {
+      'client_url': 'localhost:4243',
+      'name_from_env': None,
+      'interval': 1,
+    })
+    self.collector = DockerStatsCollector(config, None)
+
+  def test_import(self):
+    self.assertTrue(DockerStatsCollector)
+
+  @patch.object(Collector, 'publish')
+  @patch('docker.Client')
+  def test_should_publish_values_correctly(self, docker_client_mock, publish_mock):
+    client_mock = get_client_multi_network_mock()
+    docker_client_mock.return_value = client_mock
+    self.collector.collect()
+    metrics = {
+      'test.146979a53289.docker.mem.rss': 100,
+      'test.146979a53289.docker.mem.limit': 500,
+      'test.146979a53289.docker.net.eth0.tx_bytes': 100,
+      'test.146979a53289.docker.net.eth0.rx_bytes': 100,
+    }
+    self.assertPublishedMany(publish_mock, metrics)
+
+    self.collector.collect()
+    metrics = {
+      'test.146979a53289.docker.mem.rss': 200,
+      'test.146979a53289.docker.mem.limit': 500,
+      'test.146979a53289.docker.net.eth0.tx_bytes': 200,
+      'test.146979a53289.docker.net.eth0.rx_bytes': 200,
       'test.146979a53289.docker.cpu0.user': 1,
       'test.146979a53289.docker.cpu1.user': 2,
       'test.146979a53289.docker.cpu2.user': 3,
@@ -144,8 +250,8 @@ class TestDockerStatsCollectorWithEnv(CollectorTestCase):
     metrics = {
       'new.name.146979a53289.docker.mem.rss': 100,
       'new.name.146979a53289.docker.mem.limit': 500,
-      'new.name.146979a53289.docker.net.tx_bytes': 100,
-      'new.name.146979a53289.docker.net.rx_bytes': 100,
+      'new.name.146979a53289.docker.net.eth0.tx_bytes': 100,
+      'new.name.146979a53289.docker.net.eth0.rx_bytes': 100,
     }
     self.assertPublishedMany(publish_mock, metrics)
 
@@ -153,8 +259,8 @@ class TestDockerStatsCollectorWithEnv(CollectorTestCase):
     metrics = {
       'new.name.146979a53289.docker.mem.rss': 200,
       'new.name.146979a53289.docker.mem.limit': 500,
-      'new.name.146979a53289.docker.net.tx_bytes': 200,
-      'new.name.146979a53289.docker.net.rx_bytes': 200,
+      'new.name.146979a53289.docker.net.eth0.tx_bytes': 200,
+      'new.name.146979a53289.docker.net.eth0.rx_bytes': 200,
       'new.name.146979a53289.docker.cpu0.user': 1,
       'new.name.146979a53289.docker.cpu1.user': 2,
       'new.name.146979a53289.docker.cpu2.user': 3,
@@ -185,8 +291,8 @@ class TestDockerStatsCollectorWithoutReplaceSlashes(CollectorTestCase):
     metrics = {
       '/new/name/.146979a53289.docker.mem.rss': 100,
       '/new/name/.146979a53289.docker.mem.limit': 500,
-      '/new/name/.146979a53289.docker.net.tx_bytes': 100,
-      '/new/name/.146979a53289.docker.net.rx_bytes': 100,
+      '/new/name/.146979a53289.docker.net.eth0.tx_bytes': 100,
+      '/new/name/.146979a53289.docker.net.eth0.rx_bytes': 100,
     }
     self.assertPublishedMany(publish_mock, metrics)
 
@@ -194,8 +300,8 @@ class TestDockerStatsCollectorWithoutReplaceSlashes(CollectorTestCase):
     metrics = {
       '/new/name/.146979a53289.docker.mem.rss': 200,
       '/new/name/.146979a53289.docker.mem.limit': 500,
-      '/new/name/.146979a53289.docker.net.tx_bytes': 200,
-      '/new/name/.146979a53289.docker.net.rx_bytes': 200,
+      '/new/name/.146979a53289.docker.net.eth0.tx_bytes': 200,
+      '/new/name/.146979a53289.docker.net.eth0.rx_bytes': 200,
       '/new/name/.146979a53289.docker.cpu0.user': 1,
       '/new/name/.146979a53289.docker.cpu1.user': 2,
       '/new/name/.146979a53289.docker.cpu2.user': 3,
@@ -225,8 +331,8 @@ class TestDockerStatsCollectorWithECSMode(CollectorTestCase):
     metrics = {
       'ecs.name.abcdef12.docker.mem.rss': 100,
       'ecs.name.abcdef12.docker.mem.limit': 500,
-      'ecs.name.abcdef12.docker.net.tx_bytes': 100,
-      'ecs.name.abcdef12.docker.net.rx_bytes': 100,
+      'ecs.name.abcdef12.docker.net.eth0.tx_bytes': 100,
+      'ecs.name.abcdef12.docker.net.eth0.rx_bytes': 100,
     }
     self.assertPublishedMany(publish_mock, metrics)
 
@@ -234,8 +340,8 @@ class TestDockerStatsCollectorWithECSMode(CollectorTestCase):
     metrics = {
       'ecs.name.abcdef12.docker.mem.rss': 200,
       'ecs.name.abcdef12.docker.mem.limit': 500,
-      'ecs.name.abcdef12.docker.net.tx_bytes': 200,
-      'ecs.name.abcdef12.docker.net.rx_bytes': 200,
+      'ecs.name.abcdef12.docker.net.eth0.tx_bytes': 200,
+      'ecs.name.abcdef12.docker.net.eth0.rx_bytes': 200,
       'ecs.name.abcdef12.docker.cpu0.user': 1,
       'ecs.name.abcdef12.docker.cpu1.user': 2,
       'ecs.name.abcdef12.docker.cpu2.user': 3,


### PR DESCRIPTION
- ECS mode replaces container id with the first 8 digits of the ECS task
  arn, and also pulls the container name from the 'tag' docker
  label (and splits on double dashes).
- This also slightly changes the metric name to add 'docker' before the
  specific measurement.  This is for ease of matching via the influx
  graphite plugin.
