### PR TITLE
Add fd stats

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 MySQL-python
 PyYAML
 beanstalkc
+protobuf
 bernhard
 boto
 configobj


### PR DESCRIPTION
Adds a log for the number of open sockets per docker container. Tested with unit tests and it runs locally though needs to be run as root. I assume that other things need that to?

Log format locally:
`servers.vagrant-ubuntu-trusty-64.docker.tiny_goldberg.73c823597038.docker.open_sockets 0 1473981779`
